### PR TITLE
docs: fix opfs-utils page build error

### DIFF
--- a/clients/documentation/pages/packages/opfs-utils.md
+++ b/clients/documentation/pages/packages/opfs-utils.md
@@ -86,8 +86,8 @@ Safely reads one file with type-aware behavior (text, svg, media, binary) and se
 
 Apply a unified diff to OPFS. Creates/modifies/deletes/renames.
 
-- Optional isomorphic-git staging: pass { git, fs, dir, stage? }
-- Returns { success, output, details: { created, modified, deleted, renamed, failed } }
+- Optional isomorphic-git staging: pass `{ git, fs, dir, stage? }`
+- Returns `{ success, output, details: { created, modified, deleted, renamed, failed } }`
 
 ### formatTree(entries) → string
 


### PR DESCRIPTION
## Summary
- escape curly braces in opfs-utils package docs to avoid invalid attribute names

## Testing
- `npm run format:check`
- `npm run lint`
- `npx lerna run build`
- `npx lerna run test`
- `npm run build --workspace documentation`


------
https://chatgpt.com/codex/tasks/task_e_68b5587d9a888321a0d538b14d91b3ca