### PR TITLE
docs: add GitHub link to VitePress social links

### DIFF
--- a/clients/documentation/.vitepress/config.mts
+++ b/clients/documentation/.vitepress/config.mts
@@ -36,6 +36,9 @@ export default defineConfig({
         ],
       },
     ],
-    // socialLinks: [{ icon: "discord", link: "" }],
+
+    socialLinks: [
+      { icon: "github", link: "https://github.com/pufflyai/core-utils" },
+    ],
   },
 });


### PR DESCRIPTION
## Summary
- add GitHub repo link to VitePress social links for documentation site

## Testing
- `npm run format:check`
- `npm run lint`
- `npx lerna run build`
- `npx lerna run test`


------
https://chatgpt.com/codex/tasks/task_e_68b56a7c19c08321851d8e485163e54e