### PR TITLE
docs: standardize package readmes

### DIFF
--- a/packages/@pstdio/describe-context/README.md
+++ b/packages/@pstdio/describe-context/README.md
@@ -4,113 +4,33 @@
 [![license](https://img.shields.io/npm/l/describe-context)](https://github.com/pufflyai/core-utils/blob/main/LICENSE)
 [![bundle size](https://img.shields.io/bundlephobia/minzip/describe-context)](https://bundlephobia.com/package/describe-context)
 
-Analyze a folder and generate a compact Markdown “context” that’s great for LLM prompts, code reviews, and summaries. Includes a simple CLI and a small, reusable API.
+Analyze a folder and generate a compact Markdown "context" for LLM prompts, code reviews, and summaries. Includes a simple CLI and a small, reusable API.
 
-## Highlights
+For additional information, please refer to the [documentation](https://pufflyai.github.io/core-utils/packages/describe).
 
-- Directory tree + selected file contents (auto-fenced with language hints)
-- Skips large, binary, and irrelevant files with sensible defaults
-- Rough token estimate (chars/4) to keep you within LLM limits
-- Works as both a CLI (`npx describe-context`) and library (ESM)
+## Quick Start
 
----
+### Installation
 
-## Install
-
-- Library: `npm i describe-context`
-- CLI (ad‑hoc): `npx describe-context <folder>`
-
-Node 18+ recommended.
-
----
-
-## CLI
-
-Usage:
-
-```
-describe-context <folder> [output.md]
-```
-
-Examples:
-
-```
-# write to an explicit file
-npx describe-context . repo-context.md
-
-# use the default name: <folder's basename>-context.md
-npx describe-context my-project
-```
-
-What it does:
-
-- Analyzes the folder
-- Writes a Markdown file with a directory structure and relevant file contents
-- Prints basic stats to the terminal (size, estimated tokens, warnings about limits)
-
-Exit codes:
-
-- 0 on success
-- 1 on usage errors (e.g., missing folder)
-
----
-
-## Library
-
-Install:
-
-```sh
+```bash
 npm i describe-context
 ```
 
-Basic usage:
+### Usage
 
 ```ts
 import { generateContext } from "describe-context";
 
-const { markdown, files, stats } = await generateContext("/path/to/folder");
-// write markdown to disk, send to an LLM, or display it somewhere
+const { markdown } = await generateContext(".");
 ```
-
-### Lower-level building blocks
-
-If you want to customize the output, you can use the underlying helpers:
-
-```ts
-import { analyzeDirectory, generateDirectoryTree, generateFileContent, estimateTokenCount } from "describe-context";
-
-const files = await analyzeDirectory(folder, folder);
-const markdown = [generateDirectoryTree(files, folder), generateFileContent(files)].join("\n");
-const tokens = estimateTokenCount(markdown);
-```
-
----
-
-## What gets included (heuristics)
-
-Relevant by default:
-
-- Common source and config extensions: ts, js, tsx, jsx, py, rb, go, rs, java, kt, php, cs, c/cpp, html/css/scss/sass, vue/svelte/astro, json, yaml/yml, toml, ini, md/mdx, txt, rst, sql, graphql/gql, sh/bash, Dockerfile, .env variations, .gitignore, .editorconfig, prettier/eslint/tsconfig variants
-- Key meta files: README.md, CHANGELOG.md, LICENSE, CONTRIBUTING.md, Makefile, docker-compose.\*
-
-Skipped by default:
-
-- Directories: node_modules, .git, dist/build, .next/.nuxt, .vscode, .idea, coverage, vendor, tmp, logs, storybook, and similar
-- Files: lock/log/cache/temp/swap maps, minified bundles, .d.ts, various generated configs
-- Size limits: files > 1 MB are skipped; total content is capped around 10 MB
-- Binary detection: files with NUL bytes are treated as binary and skipped
-
-These defaults aren’t configurable yet. For full control, use the lower-level APIs and implement your own filters.
-
----
 
 ## Notes & limitations
 
-- Token estimate is a rough heuristic (characters/4). Real tokenizer counts vary per model.
-- Very large repos will be truncated once aggregate content reaches the size cap.
-- CLI writes the Markdown to a file (it does not stream the Markdown to stdout).
+- Token counts are rough estimates and very large folders may be truncated.
 
----
+## Contributing
+
+See the [monorepo README](https://github.com/pufflyai/core-utils#readme) for contribution guidelines.
 
 ## License
 

--- a/packages/@pstdio/opfs-sync/README.md
+++ b/packages/@pstdio/opfs-sync/README.md
@@ -4,169 +4,37 @@
 [![license](https://img.shields.io/npm/l/@pstdio/opfs-sync)](https://github.com/pufflyai/core-utils/blob/main/LICENSE)
 [![bundle size](https://img.shields.io/bundlephobia/minzip/%40pstdio%2Fopfs-sync)](https://bundlephobia.com/package/%40pstdio%2Fopfs-sync)
 
-Small, dependency-light sync engine between the browser’s Origin Private File System (OPFS) and a remote storage provider. Ships with a Supabase Storage adapter and a minimal provider interface for custom backends.
+Sync the browser's OPFS with a remote storage provider. Includes a Supabase adapter and a minimal interface for custom backends.
 
-Works entirely in the browser. Ideal for offline-first apps that keep a local OPFS workspace and reconcile with the cloud using a simple last-writer-wins strategy.
+For additional information, please refer to the [documentation](https://pufflyai.github.io/core-utils/packages/opfs-sync).
 
-## Features
+## Quick Start
 
-- Pluggable remote providers (Supabase adapter included)
-- Last-writer-wins by mtime with optional sha256 equality short-circuit
-- Evented progress reporting and error bubbling
-- Periodic background scans (opt-in with `scanInterval`)
-- Zero Node.js dependencies; ESM-only
-
-## Installation
+### Installation
 
 ```bash
 npm i @pstdio/opfs-sync
-# If you plan to use the Supabase adapter:
+# optional: remote provider SDK, e.g.
 npm i @supabase/supabase-js
 ```
 
-Requirements:
-
-- Runs in a secure context (https or localhost)
-- Browser must implement the File System Access API (OPFS)
-
-See MDN: https://developer.mozilla.org/docs/Web/API/File_System_Access_API
-
-## Quick start
+### Usage
 
 ```ts
-import { createClient } from "@supabase/supabase-js"; // only if using Supabase
-import { OpfsSync, SupabaseRemote } from "@pstdio/opfs-sync";
+import { OpfsSync } from "@pstdio/opfs-sync";
 
-// 1) Obtain an OPFS directory handle (root in this example)
 const localDir = await navigator.storage.getDirectory();
-
-// 2) Configure your remote (Supabase Storage)
-const supabase = createClient(import.meta.env.VITE_SUPABASE_URL!, import.meta.env.VITE_SUPABASE_ANON_KEY!);
-const remote = new SupabaseRemote(supabase, "my-bucket", "app/space/"); // optional prefix
-
-// 3) Create the sync instance
-const sync = new OpfsSync({ localDir, remote, scanInterval: 15_000 }); // 15s periodic scan
-
-// 4) Listen to progress and errors (optional)
-sync.addEventListener("progress", (e) => {
-  const { phase, key, transferred, total } = (e as CustomEvent).detail;
-  console.log(`[${phase}] ${key}: ${transferred}/${total}`);
-});
-sync.addEventListener("error", (e) => console.error("sync error", (e as CustomEvent).detail));
-
-// 5) Run an initial reconciliation, then start watching
+const sync = new OpfsSync({ localDir, remote: /* your provider */ });
 await sync.initialSync();
-sync.startWatching();
-
-// Later, to stop:
-// sync.stopWatching();
 ```
 
-## How it works
+## Notes & limitations
 
-- The local OPFS tree is scanned and hashed (SHA-256 of file contents) with size and `lastModified` captured.
-- The remote provider lists objects with size and modification time. If a remote `sha256` is provided, identical files are skipped.
-- For each differing path, the newer side (by mtime) wins:
-  - New local file → upload
-  - New remote file → download
-  - Both exist → last-writer-wins
+- Runs entirely in the browser and uses last-writer-wins conflict resolution.
 
-This is a simple, pragmatic strategy; there’s no CRDT/merge or rename detection.
+## Contributing
 
-## API
-
-### class OpfsSync
-
-Constructor:
-
-```ts
-new OpfsSync(options: OpfsSyncOptions)
-```
-
-Options (`OpfsSyncOptions`):
-
-- `localDir: FileSystemDirectoryHandle` — OPFS directory to sync
-- `remote: RemoteProvider` — remote backend implementation
-- `scanInterval?: number` — ms between periodic scans; `0` disables (default)
-- `encryptionKey?: Uint8Array` — reserved for future use
-
-Methods:
-
-- `initialSync(): Promise<void>` — one-shot reconciliation pass
-- `startWatching(): void` — begin periodic `initialSync()` on the interval
-- `stopWatching(): void` — stop periodic scans
-
-Events (dispatched on the `OpfsSync` instance):
-
-- `progress` — `CustomEvent<ProgressEventDetail>` with `{ phase: "upload" | "download", key, transferred, total }`
-- `error` — `CustomEvent<any>` — any error thrown by underlying operations
-
-Types exported:
-
-- `RemoteProvider`, `RemoteObject`, `OpfsSyncOptions`, `ProgressEventDetail`, `ProgressPhase`
-
-### RemoteProvider interface
-
-Implement to support a custom backend:
-
-```ts
-interface RemoteProvider {
-  list(prefix: string): Promise<Array<{ key: string; size: number; mtimeMs: number; sha256?: string }>>;
-  upload(key: string, data: Blob | ReadableStream): Promise<void>;
-  download(key: string): Promise<Blob>;
-  remove(key: string): Promise<void>;
-  updateAuth?(token?: string): void; // optional: rotate credentials
-}
-```
-
-Contract notes:
-
-- `list("")` should return a flat list of objects under the configured remote root.
-- `mtimeMs` must be milliseconds since epoch. If your backend lacks precise mtimes, approximate consistently.
-- If you can compute and return `sha256`, identical files will be skipped even when mtimes differ.
-
-### SupabaseRemote
-
-Provided adapter for Supabase Storage buckets:
-
-```ts
-new SupabaseRemote(client: SupabaseClient, bucket: string, prefix?: string)
-```
-
-- `list()` walks the bucket under `prefix`, returning objects with size and `mtimeMs` from `updated_at`.
-- `upload()` uses `upsert: true`.
-- `download()` returns a `Blob`.
-- `remove()` deletes a single key.
-- `updateAuth(token?)` can rotate a JWT if you need to refresh credentials.
-
-## Common patterns
-
-- Prompt user to pick a subdirectory under OPFS:
-
-  ```ts
-  const root = await navigator.storage.getDirectory();
-  const projects = await root.getDirectoryHandle("projects", { create: true });
-  const localDir = await projects.getDirectoryHandle("my-app", { create: true });
-  ```
-
-- Reactivity: wire `progress` to your UI and debounce totals for smooth updates.
-
-- Auth refresh: call `remote.updateAuth(newAccessToken)` on token refresh.
-
-## Caveats
-
-- Last-writer-wins can overwrite changes if clocks skew or edits race. Consider adding conflict markers in your app layer if needed.
-- No rename/move detection; renames appear as delete+create.
-- Full-content hashing happens locally; large trees may be slow on initial pass.
-- OPFS availability and quotas vary by browser; handle permission prompts gracefully.
-
-## Testing
-
-This package uses Vitest. From the package folder:
-
-```bash
-npm test
-```
+See the [monorepo README](https://github.com/pufflyai/core-utils#readme) for contribution guidelines.
 
 ## License
 

--- a/packages/@pstdio/opfs-utils/README.md
+++ b/packages/@pstdio/opfs-utils/README.md
@@ -4,65 +4,34 @@
 [![license](https://img.shields.io/npm/l/@pstdio/opfs-utils)](https://github.com/pufflyai/core-utils/blob/main/LICENSE)
 [![bundle size](https://img.shields.io/bundlephobia/minzip/%40pstdio%2Fopfs-utils)](https://bundlephobia.com/package/%40pstdio%2Fopfs-utils)
 
-Small, dependency-light utilities for working with the Origin Private File System (OPFS) in the browser.
+Small utilities for working with the browser's Origin Private File System (OPFS).
 
-> [Documentation](https://pufflyai.github.io/core-utils/packages/opfs-utils)
+For additional information, please refer to the [documentation](https://pufflyai.github.io/core-utils/packages/opfs-utils).
 
-## Installation
+## Quick Start
+
+### Installation
 
 ```bash
 npm i @pstdio/opfs-utils
-# or
-yarn add @pstdio/opfs-utils
-# or
-pnpm add @pstdio/opfs-utils
 ```
 
-## Quick start
+### Usage
 
 ```ts
-import { ls, grep, processSingleFileContent, patch, getSpecificMimeType } from "@pstdio/opfs-utils";
+import { ls } from "@pstdio/opfs-utils";
 
-// OPFS root directory handle (requires secure context, e.g., https://)
 const root = await navigator.storage.getDirectory();
-
-// 1) List files and directories (depth 2)
-const entries = await ls(root, {
-  maxDepth: 2,
-  showHidden: false,
-});
-
-console.log(entries.map((e) => `${e.kind} ${e.path}`));
-
-// 2) Grep for a string (case-insensitive)
-const matches = await grep(root, {
-  pattern: "todo",
-  flags: "i",
-  include: ["**/*.ts", "**/*.md"],
-});
-
-for (const m of matches) {
-  console.log(`${m.file}:${m.line}:${m.column}: ${m.match}`);
-}
-
-// 3) Safely read a file (with line window)
-const read = await processSingleFileContent("src/index.ts", "", root, /* offset */ 0, /* limit  */ 200);
-
-console.log(read.returnDisplay);
-console.log(typeof read.llmContent === "string" ? read.llmContent : "<binary/media>");
-
-// 4) Apply a unified diff
-const diff = `*** dummy example, replace with a real unified diff ***`;
-const result = await patch({
-  root,
-  diffContent: diff,
-});
-
-console.log(result.success, result.output);
-
-// 5) MIME lookup
-console.log(getSpecificMimeType("file.svg")); // "image/svg+xml"
+await ls(root);
 ```
+
+## Notes & limitations
+
+- Requires a secure context and browser support for the File System Access API.
+
+## Contributing
+
+See the [monorepo README](https://github.com/pufflyai/core-utils#readme) for contribution guidelines.
 
 ## License
 

--- a/packages/@pstdio/prompt-utils/README.md
+++ b/packages/@pstdio/prompt-utils/README.md
@@ -1,159 +1,36 @@
-## @pstdio/prompt-utils
+# @pstdio/prompt-utils
 
 [![npm version](https://img.shields.io/npm/v/@pstdio/prompt-utils.svg?color=blue)](https://www.npmjs.com/package/@pstdio/prompt-utils)
 [![license](https://img.shields.io/npm/l/@pstdio/prompt-utils)](https://github.com/pufflyai/core-utils/blob/main/LICENSE)
 [![bundle size](https://img.shields.io/bundlephobia/minzip/%40pstdio%2Fprompt-utils)](https://bundlephobia.com/package/%40pstdio%2Fprompt-utils)
 
-Tiny utilities for building high-quality LLM prompts and working with JSON streams. Framework-agnostic, ESM-first.
+Tiny helpers for building prompts and working with JSON streams.
 
-### Install
+For additional information, please refer to the [documentation](https://pufflyai.github.io/core-utils/packages/prompt-utils).
+
+## Quick Start
+
+### Installation
 
 ```bash
 npm i @pstdio/prompt-utils
 ```
 
-### Quick start
+### Usage
 
 ```ts
-import { prompt, line, listAnd, section, parseJSONStream } from "@pstdio/prompt-utils";
+import { prompt } from "@pstdio/prompt-utils";
 
-const title = line`
-	Summarize the following
-	customer emails
-`;
-
-const body = prompt`
-	Use a friendly tone.
-
-	Highlight ${listAnd(["issues", "requests", "next steps"])}.
-`;
-
-const content = section("INSTRUCTIONS", body);
-// <INSTRUCTIONS>\nUse a friendly tone.\n\nHighlight issues, requests and next steps.\n</INSTRUCTIONS>
-
-// Salvage a partial JSON stream (e.g., from an LLM)
-parseJSONStream('{"a":1, "b": 2'); // -> { a: 1, b: 2 }
+const p = prompt`Hello ${"world"}`;
 ```
 
-## API
+## Notes & limitations
 
-### prompt (template tag)
+- ESM-only; use `import` syntax.
 
-Multiline prompt builder that:
+## Contributing
 
-- Strips common indentation
-- Trims leading/trailing blank lines
-- Collapses runs of 3+ blank lines to 2
-
-```ts
-const p = prompt`
-	Title
-
-
-	Line 1
-		Line 2
-`;
-// "Title\n\nLine 1\n  Line 2"
-```
-
-### line (template tag)
-
-Single-line builder that normalizes whitespace: collapses newlines and multiple spaces into single spaces, then trims.
-
-```ts
-line`  A\n multi-line   title  `; // -> "A multi-line title"
-```
-
-### listAnd(items, singleLine?) / listOr(items, singleLine?)
-
-Natural-language list formatting using Oxford-style conjunctions.
-
-```ts
-listAnd(["A"]); // "A"
-listAnd(["A", "B"]); // "A and B"
-listAnd(["A", "B", "C"]); // "A, B and C"
-listOr(["A", "B"]); // "A or B"
-listAnd(["one", "two", "three"], true); // forced one line
-```
-
-### section(label, body)
-
-Wrap content in labeled markers and preserve inner formatting.
-
-```ts
-section("CONTEXT", prompt`first\n\nsecond`);
-// <CONTEXT>\nfirst\n\nsecond\n</CONTEXT>
-```
-
-### parseJSONStream(input)
-
-Attempts to parse a possibly incomplete JSON stream. If parsing the full input fails, it tries progressively shorter prefixes and auto-closes unbalanced objects/arrays when possible. Returns the parsed value or null.
-
-```ts
-parseJSONStream('{"a":1, "b":2}'); // { a: 1, b: 2 }
-parseJSONStream("[1,2,3"); // [1, 2, 3]
-parseJSONStream(""); // null
-```
-
-### getSchema(input)
-
-Derive a simple JSON-like schema from any JS value.
-
-Types used: "object", "array", "string", "number", "boolean", "null", and fallback "any".
-
-```ts
-getSchema({ a: 1, b: ["x"], c: { d: true } });
-// {
-//   type: "object",
-//   properties: {
-//     a: { type: "number" },
-//     b: { type: "array", items: { type: "string" } },
-//     c: { type: "object", properties: { d: { type: "boolean" } } }
-//   }
-// }
-```
-
-### safeParse<T = object>(str)
-
-JSON.parse wrapper that returns the parsed value on success, otherwise returns the original string.
-
-```ts
-safeParse('{"ok":true}'); // { ok: true }
-safeParse("oops"); // "oops"
-```
-
-### safeStringify(obj)
-
-Stable stringify with useful normalization:
-
-- Deterministic key order (json-stable-stringify)
-- BigInt values are converted to Number
-- Numeric-looking strings are emitted as numbers (e.g., "\"42\"" -> 42)
-
-```ts
-safeStringify({ b: 2, a: 1n, x: "007" }); // '{"a":1,"b":2,"x":7}'
-```
-
-### hashString(str)
-
-Fast FNV-1a 32-bit hash as lowercase hex.
-
-```ts
-hashString("hello"); // e.g., "4f9f2cab"
-```
-
-### shortUID(prefix = "r")
-
-Short, LLM-friendly ID using a restricted alphabet, 6 chars long (plus optional prefix).
-
-```ts
-shortUID(); // "rabc123"-style
-shortUID("t-"); // "t-xyz789"-style
-```
-
-## TypeScript and ESM
-
-This package is ESM. Import using `import ... from` in Node ESM or bundlers.
+See the [monorepo README](https://github.com/pufflyai/core-utils#readme) for contribution guidelines.
 
 ## License
 


### PR DESCRIPTION
## Summary
- align package READMEs with a concise template
- add documentation links and quick-start examples for each package

## Testing
- `npm run format:check`
- `npm run lint`
- `npx lerna run build`
- `npx lerna run test`


------
https://chatgpt.com/codex/tasks/task_e_68b56d93036483218d960fe7aca12952