### PR TITLE
feat(opfs-utils): add upload and watch helpers

### DIFF
--- a/clients/documentation/pages/packages/opfs-utils.md
+++ b/clients/documentation/pages/packages/opfs-utils.md
@@ -124,6 +124,39 @@ if (result.success) {
 }
 ```
 
+### Upload Files
+
+```ts
+import { pickAndUploadFilesToDirectory } from "@pstdio/opfs-utils";
+
+const root = await navigator.storage.getDirectory();
+const destRoot = await root.getDirectoryHandle("data", { create: true });
+
+const result = await pickAndUploadFilesToDirectory(destRoot, {
+  destSubdir: "incoming",
+  overwrite: "rename",
+});
+
+console.log(result.uploadedFiles, result.errors);
+```
+
+### Watch a Directory
+
+```ts
+import { watchDirectory } from "@pstdio/opfs-utils";
+
+const root = await navigator.storage.getDirectory();
+const dir = await root.getDirectoryHandle("data", { create: true });
+
+const stop = await watchDirectory(dir, (changes) => {
+  for (const c of changes) {
+    console.log(`[${c.type}]`, c.path.join("/"));
+  }
+});
+
+// Later: stop();
+```
+
 ## Interactive Playground
 
 Want to experiment with `@pstdio/opfs-utils`? The package includes a comprehensive **Storybook playground** where you can:

--- a/packages/@pstdio/opfs-utils/playground/Playground.stories.tsx
+++ b/packages/@pstdio/opfs-utils/playground/Playground.stories.tsx
@@ -6,6 +6,8 @@ import { PatchPanel } from "./components/PatchPanel";
 import { ReadPanel } from "./components/ReadPanel";
 import { SetupPanel } from "./components/SetupPanel";
 import { ShellPanel } from "./components/ShellPanel";
+import { UploadPanel } from "./components/UploadPanel";
+import { WatchPanel } from "./components/WatchPanel";
 import { Row, TextInput } from "./components/ui";
 import { useOPFS } from "./hooks/useOPFS";
 
@@ -46,6 +48,8 @@ function Playground() {
       <ReadPanel root={root} baseDir={baseDir} onStatus={setStatus} />
       <GrepPanel root={root} baseDir={baseDir} onStatus={setStatus} />
       <PatchPanel root={root} baseDir={baseDir} onStatus={setStatus} />
+      <UploadPanel root={root} baseDir={baseDir} onStatus={setStatus} />
+      <WatchPanel root={root} baseDir={baseDir} onStatus={setStatus} />
       <ShellPanel root={root} baseDir={baseDir} onStatus={setStatus} />
     </div>
   );

--- a/packages/@pstdio/opfs-utils/playground/components/UploadPanel.tsx
+++ b/packages/@pstdio/opfs-utils/playground/components/UploadPanel.tsx
@@ -1,0 +1,104 @@
+import { useState } from "react";
+import {
+  pickAndUploadFilesToDirectory,
+  uploadFilesToDirectory,
+  type FileUploadBaseOptions,
+  type FileUploadResult,
+} from "../../src/utils/opfs-upload";
+import { getDirHandle } from "../opfs-helpers";
+import { Button, MonoBlock, Row, Section, TextInput } from "./ui";
+
+export function UploadPanel({
+  root,
+  baseDir,
+  onStatus,
+}: {
+  root: FileSystemDirectoryHandle | null;
+  baseDir: string;
+  onStatus: (s: string) => void;
+}) {
+  const [destSubdir, setDestSubdir] = useState("");
+  const [overwrite, setOverwrite] = useState<FileUploadBaseOptions["overwrite"]>("replace");
+  const [accept, setAccept] = useState(".csv,.json,.txt,.xlsx,.parquet");
+  const [multiple, setMultiple] = useState(true);
+  const [result, setResult] = useState<FileUploadResult | null>(null);
+
+  async function getDestRoot() {
+    if (!root) return null;
+    return await getDirHandle(root, baseDir, true);
+  }
+
+  async function handlePick() {
+    const dir = await getDestRoot();
+    if (!dir) return;
+    onStatus("Picking...");
+    try {
+      const res = await pickAndUploadFilesToDirectory(dir, {
+        destSubdir,
+        overwrite,
+        accept,
+        multiple,
+      });
+      setResult(res);
+      onStatus(`Uploaded ${res.uploadedFiles.length} files`);
+    } catch (e) {
+      onStatus((e as Error).message);
+    }
+  }
+
+  async function handleProgrammatic() {
+    const dir = await getDestRoot();
+    if (!dir) return;
+    onStatus("Uploading...");
+    const f = new File(["demo"], "demo.txt", { type: "text/plain" });
+    const res = await uploadFilesToDirectory(dir, [f], { destSubdir, overwrite });
+    setResult(res);
+    onStatus(`Uploaded ${res.uploadedFiles.length} files`);
+  }
+
+  return (
+    <Section title="Upload">
+      <Row>
+        <TextInput
+          label="Destination subdir"
+          value={destSubdir}
+          onChange={(e) => setDestSubdir(e.currentTarget.value)}
+          width={200}
+        />
+        <div>
+          <label style={{ display: "block", fontSize: 12, color: "#555", marginBottom: 6 }}>Overwrite</label>
+          <select
+            value={overwrite}
+            onChange={(e) => setOverwrite(e.currentTarget.value as any)}
+            style={{
+              padding: "6px 8px",
+              border: "1px solid #ccc",
+              borderRadius: 6,
+            }}
+          >
+            <option value="replace">replace</option>
+            <option value="skip">skip</option>
+            <option value="rename">rename</option>
+          </select>
+        </div>
+        <TextInput label="Accept" value={accept} onChange={(e) => setAccept(e.currentTarget.value)} width={160} />
+        <label style={{ display: "flex", alignItems: "center", gap: 6 }}>
+          <input type="checkbox" checked={multiple} onChange={(e) => setMultiple(e.currentTarget.checked)} />
+          Multiple
+        </label>
+        <Button onClick={handlePick} disabled={!root}>
+          Pick & Upload
+        </Button>
+        <Button onClick={handleProgrammatic} disabled={!root}>
+          Upload (demo)
+        </Button>
+      </Row>
+      {result && (
+        <div style={{ marginTop: 8 }}>
+          <p>Uploaded files</p>
+          <MonoBlock height={120}>{result.uploadedFiles.concat(result.errors).join("\n")}</MonoBlock>
+        </div>
+      )}
+    </Section>
+  );
+}

--- a/packages/@pstdio/opfs-utils/playground/components/WatchPanel.tsx
+++ b/packages/@pstdio/opfs-utils/playground/components/WatchPanel.tsx
@@ -1,0 +1,112 @@
+import { useState } from "react";
+import {
+  watchDirectory,
+  type ChangeRecord,
+  type DirectoryWatcherCleanup,
+  type WatchOptions,
+} from "../../src/utils/opfs-watch";
+import { getDirHandle } from "../opfs-helpers";
+import { Button, MonoBlock, Row, Section, TextInput } from "./ui";
+
+export function WatchPanel({
+  root,
+  baseDir,
+  onStatus,
+}: {
+  root: FileSystemDirectoryHandle | null;
+  baseDir: string;
+  onStatus: (s: string) => void;
+}) {
+  const [intervalMs, setIntervalMs] = useState(1500);
+  const [pauseWhenHidden, setPauseWhenHidden] = useState(true);
+  const [emitInitial, setEmitInitial] = useState(false);
+  const [recursive, setRecursive] = useState(true);
+  const [ignore, setIgnore] = useState("");
+  const [changes, setChanges] = useState<ChangeRecord[]>([]);
+  const [stopper, setStopper] = useState<DirectoryWatcherCleanup | null>(null);
+
+  async function handleStart() {
+    if (!root) return;
+    const dir = await getDirHandle(root, baseDir, true);
+
+    const opts: WatchOptions = {
+      intervalMs,
+      pauseWhenHidden,
+      emitInitial,
+      recursive,
+    };
+
+    if (ignore.trim()) {
+      const regs = ignore
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean)
+        .map((s) => new RegExp(s));
+      opts.ignore = regs;
+    }
+
+    onStatus("Watching...");
+    const stop = await watchDirectory(
+      dir,
+      (cs) => {
+        setChanges((prev) => [...prev, ...cs]);
+      },
+      opts,
+    );
+    setStopper(() => stop);
+  }
+
+  function handleStop() {
+    stopper?.();
+    setStopper(null);
+    onStatus("Stopped watching");
+  }
+
+  return (
+    <Section title="Watch">
+      <Row>
+        <TextInput
+          label="intervalMs"
+          type="number"
+          value={String(intervalMs)}
+          onChange={(e) => setIntervalMs(Number(e.currentTarget.value))}
+          width={100}
+        />
+        <label style={{ display: "flex", alignItems: "center", gap: 6 }}>
+          <input
+            type="checkbox"
+            checked={pauseWhenHidden}
+            onChange={(e) => setPauseWhenHidden(e.currentTarget.checked)}
+          />
+          Pause when hidden
+        </label>
+        <label style={{ display: "flex", alignItems: "center", gap: 6 }}>
+          <input type="checkbox" checked={emitInitial} onChange={(e) => setEmitInitial(e.currentTarget.checked)} />
+          Emit initial
+        </label>
+        <label style={{ display: "flex", alignItems: "center", gap: 6 }}>
+          <input type="checkbox" checked={recursive} onChange={(e) => setRecursive(e.currentTarget.checked)} />
+          Recursive
+        </label>
+        <TextInput
+          label="Ignore (regex, comma)"
+          value={ignore}
+          onChange={(e) => setIgnore(e.currentTarget.value)}
+          width={200}
+        />
+        {stopper ? (
+          <Button onClick={handleStop}>Stop</Button>
+        ) : (
+          <Button onClick={handleStart} disabled={!root}>
+            Start
+          </Button>
+        )}
+      </Row>
+      {changes.length > 0 && (
+        <div style={{ marginTop: 8 }}>
+          <MonoBlock height={180}>{changes.map((c) => `${c.type} ${c.path.join("/")}`).join("\n")}</MonoBlock>
+        </div>
+      )}
+    </Section>
+  );
+}

--- a/packages/@pstdio/opfs-utils/src/index.ts
+++ b/packages/@pstdio/opfs-utils/src/index.ts
@@ -9,3 +9,16 @@ export {
 export { grep } from "./utils/opfs-grep";
 export { formatTree, ls } from "./utils/opfs-ls";
 export { applyPatchInOPFS as patch } from "./utils/opfs-patch";
+export {
+  pickAndUploadFilesToDirectory,
+  uploadFilesToDirectory,
+  type FileUploadBaseOptions,
+  type FileUploadResult,
+} from "./utils/opfs-upload";
+export {
+  watchOPFS,
+  watchDirectory,
+  type ChangeRecord,
+  type DirectoryWatcherCleanup,
+  type WatchOptions,
+} from "./utils/opfs-watch";

--- a/packages/@pstdio/opfs-utils/src/utils/opfs-upload.test.ts
+++ b/packages/@pstdio/opfs-utils/src/utils/opfs-upload.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { setupTestOPFS } from "../__helpers__/test-opfs";
+import { getOPFSRoot } from "../shared";
+import { pickAndUploadFilesToDirectory, uploadFilesToDirectory } from "./opfs-upload";
+
+async function readText(dir: FileSystemDirectoryHandle, path: string) {
+  const parts = path.split("/");
+  let cur = dir;
+
+  for (let i = 0; i < parts.length - 1; i++) {
+    cur = await cur.getDirectoryHandle(parts[i], { create: false });
+  }
+
+  const fh = await cur.getFileHandle(parts[parts.length - 1], { create: false });
+  const f = await fh.getFile();
+  return await f.text();
+}
+
+describe("uploadFilesToDirectory", () => {
+  it("uploads with path options and overwrite modes", async () => {
+    setupTestOPFS();
+    const root = await getOPFSRoot();
+    const destRoot = await (root as any).getDirectoryHandle("dst", { create: true });
+
+    const fileA = new File(["hi"], "a.txt");
+    await uploadFilesToDirectory(destRoot, [fileA]);
+    expect(await readText(destRoot, "a.txt")).toBe("hi");
+
+    const fileB = new File(["hi"], "b.txt");
+    await uploadFilesToDirectory(destRoot, [fileB], { destSubdir: "inbox" });
+    expect(await readText(destRoot, "inbox/b.txt")).toBe("hi");
+
+    const fileC = new File(["hi"], "c.txt");
+    await uploadFilesToDirectory(destRoot, [fileC], {
+      pathMapper: (f) => `by-type/text/${f.name}`,
+    });
+    expect(await readText(destRoot, "by-type/text/c.txt")).toBe("hi");
+
+    const big1 = new File(["1"], "d.txt");
+    await uploadFilesToDirectory(destRoot, [big1]);
+
+    const big2 = new File(["22"], "d.txt");
+    await uploadFilesToDirectory(destRoot, [big2], { overwrite: "replace" });
+    expect(await readText(destRoot, "d.txt")).toBe("22");
+
+    const skip1 = new File(["orig"], "e.txt");
+    await uploadFilesToDirectory(destRoot, [skip1]);
+    const skip2 = new File(["new"], "e.txt");
+    const rSkip = await uploadFilesToDirectory(destRoot, [skip2], { overwrite: "skip" });
+    expect(await readText(destRoot, "e.txt")).toBe("orig");
+    expect(rSkip.errors.length).toBe(1);
+
+    const rn1 = new File(["x"], "f.txt");
+    await uploadFilesToDirectory(destRoot, [rn1]);
+    const rn2 = new File(["y"], "f.txt");
+    await uploadFilesToDirectory(destRoot, [rn2], { overwrite: "rename" });
+    expect(await readText(destRoot, "f.txt")).toBe("x");
+    expect(await readText(destRoot, "f (1).txt")).toBe("y");
+  });
+});
+
+describe("pickAndUploadFilesToDirectory", () => {
+  it("throws without DOM", async () => {
+    setupTestOPFS();
+    const root = await getOPFSRoot();
+    await expect(pickAndUploadFilesToDirectory(root, { accept: "*/*" })).rejects.toThrow();
+  });
+});

--- a/packages/@pstdio/opfs-utils/src/utils/opfs-upload.ts
+++ b/packages/@pstdio/opfs-utils/src/utils/opfs-upload.ts
@@ -1,0 +1,190 @@
+export interface FileUploadBaseOptions {
+  destSubdir?: string;
+  pathMapper?: (file: File) => string;
+  overwrite?: "replace" | "skip" | "rename";
+  onProgress?: (info: { index: number; total: number; filename: string; destPath: string }) => void;
+}
+
+export interface PickerOptions {
+  /** Accepted file types. Default: "" (allow all) */
+  accept?: string;
+  /** Allow selecting multiple files. Default: true */
+  multiple?: boolean;
+}
+
+export interface FileUploadResult {
+  success: boolean;
+  uploadedFiles: string[];
+  errors: string[];
+}
+
+export async function pickAndUploadFilesToDirectory(
+  destRoot: FileSystemDirectoryHandle,
+  options: FileUploadBaseOptions & PickerOptions = {},
+): Promise<FileUploadResult> {
+  if (typeof document === "undefined") {
+    throw new Error("DOM not available; use uploadFilesToDirectory instead.");
+  }
+
+  const { accept = "", multiple = true } = options;
+
+  return new Promise((resolve) => {
+    const input = document.createElement("input");
+    input.type = "file";
+    input.accept = accept;
+    input.multiple = multiple;
+
+    input.addEventListener("change", async () => {
+      const files = Array.from(input.files || []);
+      if (!files.length) {
+        resolve({ success: false, uploadedFiles: [], errors: ["No files selected"] });
+        return;
+      }
+
+      resolve(await uploadFilesToDirectory(destRoot, files, options));
+    });
+
+    input.click();
+  });
+}
+
+export async function uploadFilesToDirectory(
+  destRoot: FileSystemDirectoryHandle,
+  files: File[],
+  options: FileUploadBaseOptions = {},
+): Promise<FileUploadResult> {
+  const uploadedFiles: string[] = [];
+  const errors: string[] = [];
+
+  const total = files.length;
+  const overwrite = options.overwrite ?? "replace";
+
+  for (let i = 0; i < files.length; i++) {
+    const file = files[i];
+    const destRel = resolvePath(file, options);
+
+    if (destRel == null) {
+      errors.push(`Invalid destination for ${file.name}`);
+      continue;
+    }
+
+    let finalPath = destRel;
+
+    try {
+      if (overwrite === "skip" && (await fileExists(destRoot, destRel))) {
+        errors.push(`File exists, skipped: ${destRel}`);
+        continue;
+      }
+
+      if (overwrite === "rename" && (await fileExists(destRoot, destRel))) {
+        const renamed = await findAvailableName(destRoot, destRel);
+        if (!renamed) {
+          errors.push(`File exists, cannot rename: ${destRel}`);
+          continue;
+        }
+        finalPath = renamed;
+      }
+
+      const dir = await getDirHandle(destRoot, parentOf(finalPath), true);
+      const fh = await dir.getFileHandle(basename(finalPath), { create: true });
+      const w = await fh.createWritable();
+
+      const data = await file.arrayBuffer();
+      await w.write(data);
+      await w.close();
+
+      uploadedFiles.push(finalPath);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      errors.push(`Failed to upload ${file.name}: ${msg}`);
+    } finally {
+      options.onProgress?.({ index: i, total, filename: file.name, destPath: finalPath });
+    }
+  }
+
+  return { success: errors.length === 0, uploadedFiles, errors };
+}
+
+function resolvePath(file: File, options: FileUploadBaseOptions): string | null {
+  const { pathMapper, destSubdir } = options;
+
+  let raw: string;
+  if (pathMapper) {
+    raw = pathMapper(file);
+  } else if (destSubdir) {
+    raw = joinPath(destSubdir, file.name);
+  } else {
+    raw = file.name;
+  }
+
+  const segs = normalizeSegments(raw);
+  return segs.join("/");
+}
+
+async function fileExists(root: FileSystemDirectoryHandle, path: string): Promise<boolean> {
+  try {
+    const dir = await getDirHandle(root, parentOf(path), false);
+    await dir.getFileHandle(basename(path), { create: false });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function findAvailableName(root: FileSystemDirectoryHandle, path: string): Promise<string | null> {
+  const dirPath = parentOf(path);
+  const base = basename(path);
+  const { name, ext } = splitExt(base);
+
+  for (let i = 1; i < 1000; i++) {
+    const candidate = joinPath(dirPath, `${name} (${i})${ext}`);
+    if (!(await fileExists(root, candidate))) return candidate;
+  }
+
+  return null;
+}
+
+async function getDirHandle(root: FileSystemDirectoryHandle, path: string, create: boolean) {
+  if (!path) return root;
+
+  let cur = root;
+  for (const seg of normalizeSegments(path)) {
+    cur = await cur.getDirectoryHandle(seg, { create });
+  }
+  return cur;
+}
+
+function normalizeSegments(p: string): string[] {
+  const out: string[] = [];
+
+  for (const part of p.split("/")) {
+    const s = part.trim();
+    if (!s || s === ".") continue;
+    if (s === "..") {
+      if (out.length) out.pop();
+      continue;
+    }
+    out.push(s);
+  }
+
+  return out;
+}
+
+function joinPath(a: string, b: string) {
+  return normalizeSegments(`${a}/${b}`).join("/");
+}
+
+function parentOf(p: string): string {
+  const i = p.lastIndexOf("/");
+  return i === -1 ? "" : p.slice(0, i);
+}
+
+function basename(p: string): string {
+  const i = p.lastIndexOf("/");
+  return i === -1 ? p : p.slice(i + 1);
+}
+
+function splitExt(name: string): { name: string; ext: string } {
+  const i = name.lastIndexOf(".");
+  return i === -1 ? { name, ext: "" } : { name: name.slice(0, i), ext: name.slice(i) };
+}

--- a/packages/@pstdio/opfs-utils/src/utils/opfs-watch.test.ts
+++ b/packages/@pstdio/opfs-utils/src/utils/opfs-watch.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from "vitest";
+import { setupTestOPFS, writeFile } from "../__helpers__/test-opfs";
+import { getOPFSRoot } from "../shared";
+import { watchDirectory } from "./opfs-watch";
+
+describe("watchDirectory polling", () => {
+  it("emits changes on create/modify/delete", async () => {
+    setupTestOPFS();
+    const root = await getOPFSRoot();
+    const dir = await (root as any).getDirectoryHandle("w", { create: true });
+
+    const records: any[] = [];
+
+    vi.useFakeTimers();
+    await watchDirectory(
+      dir,
+      (c) => {
+        records.push(...c);
+      },
+      { intervalMs: 10, pauseWhenHidden: false },
+    );
+
+    await writeFile(dir, "a.txt", "1");
+    await vi.advanceTimersByTimeAsync(20);
+    expect(records.find((r) => r.type === "appeared" && r.path.join("/") === "a.txt")).toBeTruthy();
+
+    records.length = 0;
+    await writeFile(dir, "a.txt", "22");
+    await vi.advanceTimersByTimeAsync(20);
+    expect(records.find((r) => r.type === "modified" && r.path.join("/") === "a.txt")).toBeTruthy();
+
+    records.length = 0;
+    await dir.removeEntry("a.txt");
+    await vi.advanceTimersByTimeAsync(20);
+    expect(records.find((r) => r.type === "disappeared" && r.path.join("/") === "a.txt")).toBeTruthy();
+
+    vi.useRealTimers();
+  });
+});

--- a/packages/@pstdio/opfs-utils/src/utils/opfs-watch.ts
+++ b/packages/@pstdio/opfs-utils/src/utils/opfs-watch.ts
@@ -1,0 +1,159 @@
+import { getOPFSRoot } from "../shared";
+
+export type DirectoryWatcherCleanup = () => void;
+export type ChangeType = "appeared" | "modified" | "disappeared" | "moved" | "unknown" | "errored";
+
+export interface ChangeRecord {
+  type: ChangeType;
+  path: string[];
+  size?: number;
+  lastModified?: number;
+  handleKind?: FileSystemHandle["kind"];
+}
+
+export interface WatchOptions {
+  intervalMs?: number;
+  pauseWhenHidden?: boolean;
+  emitInitial?: boolean;
+  recursive?: boolean;
+  signal?: AbortSignal;
+  ignore?: RegExp | RegExp[] | ((path: string[], handle: FileSystemHandle) => boolean);
+}
+
+export async function watchOPFS(
+  callback: (changes: ChangeRecord[]) => void,
+  options?: WatchOptions,
+): Promise<DirectoryWatcherCleanup> {
+  const root = await getOPFSRoot();
+  return watchDirectory(root, callback, options);
+}
+
+export async function watchDirectory(
+  dir: FileSystemDirectoryHandle,
+  callback: (changes: ChangeRecord[]) => void,
+  options: WatchOptions = {},
+): Promise<DirectoryWatcherCleanup> {
+  const { intervalMs = 1500, pauseWhenHidden = true, emitInitial = false, recursive = true, signal, ignore } = options;
+
+  const ignoreFn = toIgnoreFn(ignore);
+
+  const ObserverCtor: any = (globalThis as any).FileSystemObserver;
+  if (typeof ObserverCtor === "function") {
+    const observer = new ObserverCtor((records: any[]) => {
+      const changes: ChangeRecord[] = [];
+
+      for (const r of records) {
+        const p: string[] = r.relativePathComponents || [r.name || ""];
+        changes.push({
+          type: r.type || "unknown",
+          path: p,
+          size: r.size,
+          lastModified: r.lastModified,
+          handleKind: r.kind,
+        });
+      }
+
+      if (changes.length) callback(changes);
+    });
+
+    await observer.observe(dir, { recursive });
+
+    const cleanup = () => observer.disconnect();
+    signal?.addEventListener("abort", cleanup);
+    return cleanup;
+  }
+
+  let prev = new Map<string, { size: number; mtime: number; kind: string }>();
+
+  async function snap() {
+    const cur = new Map<string, { size: number; mtime: number; kind: string }>();
+    await walk(dir, [], cur);
+    const changes: ChangeRecord[] = [];
+
+    for (const [path, meta] of cur) {
+      const before = prev.get(path);
+      if (!before) {
+        changes.push({
+          type: "appeared",
+          path: path.split("/"),
+          size: meta.size,
+          lastModified: meta.mtime,
+          handleKind: meta.kind as any,
+        });
+      } else if (before.size !== meta.size || before.mtime !== meta.mtime) {
+        changes.push({
+          type: "modified",
+          path: path.split("/"),
+          size: meta.size,
+          lastModified: meta.mtime,
+          handleKind: meta.kind as any,
+        });
+      }
+    }
+
+    for (const [path] of prev) {
+      if (!cur.has(path)) {
+        changes.push({ type: "disappeared", path: path.split("/") });
+      }
+    }
+
+    if (changes.length) callback(changes);
+    prev = cur;
+  }
+
+  async function walk(
+    d: FileSystemDirectoryHandle,
+    prefix: string[],
+    out: Map<string, { size: number; mtime: number; kind: string }>,
+  ) {
+    for await (const [name, handle] of (d as any).entries() as any) {
+      const path = [...prefix, name];
+      if (ignoreFn(path, handle)) continue;
+
+      if (handle.kind === "directory") {
+        out.set(path.join("/"), { size: 0, mtime: 0, kind: handle.kind });
+        await walk(handle, path, out);
+      } else if (handle.kind === "file") {
+        const f = await handle.getFile();
+        out.set(path.join("/"), {
+          size: f.size,
+          mtime: f.lastModified,
+          kind: handle.kind,
+        });
+      }
+    }
+  }
+
+  if (emitInitial) await snap();
+
+  let timer = setInterval(snap, intervalMs);
+
+  let visListener: (() => void) | null = null;
+  if (pauseWhenHidden && typeof document !== "undefined") {
+    const onVis = () => {
+      if (document.visibilityState === "hidden") {
+        clearInterval(timer);
+      } else {
+        snap();
+        timer = setInterval(snap, intervalMs);
+      }
+    };
+    document.addEventListener("visibilitychange", onVis);
+    visListener = () => document.removeEventListener("visibilitychange", onVis);
+  }
+
+  const cleanup = () => {
+    clearInterval(timer);
+    visListener?.();
+  };
+
+  signal?.addEventListener("abort", cleanup);
+  return cleanup;
+}
+
+function toIgnoreFn(ignore: WatchOptions["ignore"]): (path: string[], handle: FileSystemHandle) => boolean {
+  if (!ignore) return () => false;
+  if (typeof ignore === "function") return ignore;
+  const regs = Array.isArray(ignore) ? ignore : [ignore];
+  return (path) => regs.some((r) => r.test(path.join("/")));
+}


### PR DESCRIPTION
## Summary
- add `uploadFilesToDirectory` and `pickAndUploadFilesToDirectory` helpers
- expose OPFS directory watchers with observer and polling fallbacks
- wire up Storybook panels and docs for upload and watch utilities
- remove redundant documentation link from README

## Testing
- `npm run format:check`
- `npm run lint`
- `npx lerna run build`
- `npx lerna run test`


------
https://chatgpt.com/codex/tasks/task_e_68b59fb1ebf08321bcf8e415a9642f78