### PR TITLE
feat(opfs-utils): add OPFS CRUD helpers

### DIFF
--- a/clients/documentation/pages/packages/opfs-utils.md
+++ b/clients/documentation/pages/packages/opfs-utils.md
@@ -124,6 +124,19 @@ if (result.success) {
 }
 ```
 
+### CRUD helpers
+
+```ts
+import { readFile, writeFile, deleteFile, downloadFile } from "@pstdio/opfs-utils";
+
+await writeFile("data/inbox/hello.txt", "Hi!");
+const text = await readFile("data/inbox/hello.txt"); // "Hi!"
+await deleteFile("data/inbox/hello.txt");
+
+// In a browser page:
+await downloadFile("data/report.csv"); // triggers a download
+```
+
 ### Upload Files
 
 ```ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -20338,6 +20338,7 @@
         "@types/react": "^19.1.9",
         "@types/react-dom": "^19.1.7",
         "concurrently": "^9.1.2",
+        "jsdom": "^25.0.1",
         "playwright": "^1.54.2",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",

--- a/packages/@pstdio/opfs-utils/package.json
+++ b/packages/@pstdio/opfs-utils/package.json
@@ -56,6 +56,7 @@
     "@types/react": "^19.1.9",
     "@types/react-dom": "^19.1.7",
     "concurrently": "^9.1.2",
+    "jsdom": "^25.0.1",
     "playwright": "^1.54.2",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",

--- a/packages/@pstdio/opfs-utils/playground/Playground.stories.tsx
+++ b/packages/@pstdio/opfs-utils/playground/Playground.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
+import { CrudPanel } from "./components/CrudPanel";
 import { GrepPanel } from "./components/GrepPanel";
 import { LsPanel } from "./components/LsPanel";
 import { PatchPanel } from "./components/PatchPanel";
@@ -51,6 +52,7 @@ function Playground() {
       <UploadPanel root={root} baseDir={baseDir} onStatus={setStatus} />
       <WatchPanel root={root} baseDir={baseDir} onStatus={setStatus} />
       <ShellPanel root={root} baseDir={baseDir} onStatus={setStatus} />
+      <CrudPanel baseDir={baseDir} onStatus={setStatus} />
     </div>
   );
 }

--- a/packages/@pstdio/opfs-utils/playground/components/CrudPanel.tsx
+++ b/packages/@pstdio/opfs-utils/playground/components/CrudPanel.tsx
@@ -1,0 +1,93 @@
+import { useState } from "react";
+import {
+  readFile as opfsRead,
+  writeFile as opfsWrite,
+  deleteFile as opfsDelete,
+  downloadFile as opfsDownload,
+} from "../../src/utils/opfs-crud";
+import { Button, MonoBlock, Row, Section, TextArea, TextInput } from "./ui";
+
+export function CrudPanel({ baseDir: _baseDir, onStatus }: { baseDir: string; onStatus: (s: string) => void }) {
+  void _baseDir;
+
+  const [path, setPath] = useState("playground/docs/sample.txt");
+  const [contents, setContents] = useState("Hello OPFS!");
+  const [output, setOutput] = useState<string>("");
+
+  const fullPath = path; // already relative to OPFS root; include baseDir yourself if desired
+
+  async function handleRead() {
+    onStatus("Reading...");
+
+    try {
+      const text = await opfsRead(fullPath);
+      setOutput(text);
+      onStatus("Read OK.");
+    } catch (e: any) {
+      setOutput(String(e?.message || e));
+      onStatus("Read failed.");
+    }
+  }
+
+  async function handleWrite() {
+    onStatus("Writing...");
+
+    try {
+      await opfsWrite(fullPath, contents);
+      onStatus("Write OK.");
+    } catch (e: any) {
+      onStatus(`Write failed: ${e?.message || e}`);
+    }
+  }
+
+  async function handleDelete() {
+    onStatus("Deleting...");
+
+    try {
+      await opfsDelete(fullPath);
+      onStatus("Delete OK.");
+    } catch (e: any) {
+      onStatus(`Delete failed: ${e?.message || e}`);
+    }
+  }
+
+  async function handleDownload() {
+    onStatus("Downloading...");
+
+    try {
+      await opfsDownload(fullPath);
+      onStatus("Download triggered.");
+    } catch (e: any) {
+      onStatus(`Download failed: ${e?.message || e}`);
+    }
+  }
+
+  return (
+    <Section title="CRUD (read/write/delete/download)">
+      <Row>
+        <TextInput
+          label="Path (relative to OPFS root)"
+          value={path}
+          onChange={(e) => setPath(e.currentTarget.value)}
+          width={360}
+        />
+      </Row>
+      <Row>
+        <Button onClick={handleRead}>Read</Button>
+        <Button onClick={handleWrite}>Write</Button>
+        <Button tone="danger" onClick={handleDelete}>
+          Delete
+        </Button>
+        <Button onClick={handleDownload}>Download</Button>
+      </Row>
+
+      <div style={{ marginTop: 10 }}>
+        <TextArea label="Content (for write)" value={contents} onChange={(e) => setContents(e.currentTarget.value)} />
+      </div>
+
+      <div style={{ marginTop: 10 }}>
+        <MonoBlock height={160}>{output || "No output yet."}</MonoBlock>
+      </div>
+    </Section>
+  );
+}

--- a/packages/@pstdio/opfs-utils/src/index.ts
+++ b/packages/@pstdio/opfs-utils/src/index.ts
@@ -22,3 +22,4 @@ export {
   type DirectoryWatcherCleanup,
   type WatchOptions,
 } from "./utils/opfs-watch";
+export { readFile, writeFile, deleteFile, downloadFile } from "./utils/opfs-crud";

--- a/packages/@pstdio/opfs-utils/src/utils/opfs-crud.dom.test.ts
+++ b/packages/@pstdio/opfs-utils/src/utils/opfs-crud.dom.test.ts
@@ -1,0 +1,31 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, expect, it, vi } from "vitest";
+import { setupTestOPFS } from "../__helpers__/test-opfs";
+import { downloadFile, writeFile } from "./opfs-crud";
+
+describe("opfs-crud downloadFile (jsdom)", () => {
+  it("creates an object URL and clicks a link", async () => {
+    setupTestOPFS();
+
+    await writeFile("d1/file.txt", "payload");
+
+    const createSpy = vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:fake");
+    const revokeSpy = vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+    const appendSpy = vi.spyOn(document.body, "appendChild");
+    const removeSpy = vi.spyOn(HTMLElement.prototype, "remove");
+
+    await downloadFile("d1/file.txt");
+
+    expect(createSpy).toHaveBeenCalledTimes(1);
+    expect(appendSpy).toHaveBeenCalledTimes(1);
+    expect(removeSpy).toHaveBeenCalledTimes(1);
+    expect(revokeSpy).toHaveBeenCalledWith("blob:fake");
+
+    createSpy.mockRestore();
+    revokeSpy.mockRestore();
+    appendSpy.mockRestore();
+    removeSpy.mockRestore();
+  });
+});

--- a/packages/@pstdio/opfs-utils/src/utils/opfs-crud.test.ts
+++ b/packages/@pstdio/opfs-utils/src/utils/opfs-crud.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { setupTestOPFS } from "../__helpers__/test-opfs";
+import { getOPFSRoot } from "../shared";
+import { readFile, writeFile, deleteFile } from "./opfs-crud";
+
+describe("opfs-crud (node env)", () => {
+  it("write -> read roundtrip", async () => {
+    setupTestOPFS();
+
+    await writeFile("alpha/beta/hello.txt", "hi");
+    await expect(readFile("alpha/beta/hello.txt")).resolves.toBe("hi");
+  });
+
+  it("delete removes the file", async () => {
+    setupTestOPFS();
+
+    await writeFile("x/y/z.txt", "zap");
+    await deleteFile("x/y/z.txt");
+    await expect(readFile("x/y/z.txt")).rejects.toMatchObject({ name: "NotFoundError" });
+  });
+
+  it("reading a missing file rejects with NotFoundError", async () => {
+    setupTestOPFS();
+
+    await expect(readFile("missing.txt")).rejects.toMatchObject({ name: "NotFoundError" });
+  });
+
+  it("writes create parent directories", async () => {
+    setupTestOPFS();
+
+    await writeFile("nested/dir/leaf.txt", "content");
+
+    const root = await getOPFSRoot();
+    const d1 = await (root as any).getDirectoryHandle("nested");
+    const d2 = await d1.getDirectoryHandle("dir");
+    const fh = await d2.getFileHandle("leaf.txt");
+    const text = await (await fh.getFile()).text();
+
+    expect(text).toBe("content");
+  });
+});

--- a/packages/@pstdio/opfs-utils/src/utils/opfs-crud.ts
+++ b/packages/@pstdio/opfs-utils/src/utils/opfs-crud.ts
@@ -1,0 +1,105 @@
+import { getOPFSRoot } from "../shared";
+
+/** Normalize to POSIX-ish, strip leading slashes. */
+function normalizeRelPath(p: string): string {
+  return p.replace(/\\/g, "/").replace(/^\/+/, "").trim();
+}
+
+/** Walk to the parent directory of a path. */
+async function getParentDirHandle(
+  root: FileSystemDirectoryHandle,
+  path: string,
+  create: boolean,
+): Promise<FileSystemDirectoryHandle> {
+  const segs = normalizeRelPath(path).split("/").filter(Boolean);
+
+  let dir = root;
+  for (const segment of segs.slice(0, -1)) {
+    dir = await dir.getDirectoryHandle(segment, { create });
+  }
+
+  return dir;
+}
+
+/**
+ * Read a file from OPFS and return its text content.
+ * Throws DOMException(NotFoundError) if path is missing.
+ */
+export const readFile = async (path: string): Promise<string> => {
+  const root = await getOPFSRoot();
+  const normalized = normalizeRelPath(path);
+
+  const dir = await getParentDirHandle(root, normalized, /*create*/ false);
+  const base = normalized.split("/").pop()!;
+
+  const fh = await dir.getFileHandle(base, { create: false });
+  const f = await fh.getFile();
+
+  return f.text();
+};
+
+/**
+ * Write a text file to OPFS, creating parent directories as needed.
+ * Overwrites if the file already exists.
+ */
+export const writeFile = async (path: string, contents: string): Promise<void> => {
+  const root = await getOPFSRoot();
+  const normalized = normalizeRelPath(path);
+
+  const dir = await getParentDirHandle(root, normalized, /*create*/ true);
+  const base = normalized.split("/").pop()!;
+
+  const fh = await dir.getFileHandle(base, { create: true });
+  const w = await fh.createWritable();
+
+  try {
+    await w.write(contents);
+  } finally {
+    await w.close();
+  }
+};
+
+/**
+ * Delete a file from OPFS.
+ * Throws DOMException(NotFoundError) if path is missing.
+ */
+export const deleteFile = async (path: string): Promise<void> => {
+  const root = await getOPFSRoot();
+  const normalized = normalizeRelPath(path);
+
+  const dir = await getParentDirHandle(root, normalized, /*create*/ false);
+  const base = normalized.split("/").pop()!;
+
+  await dir.removeEntry(base);
+};
+
+/**
+ * Trigger a browser download of a file stored in OPFS.
+ * Requires a DOM environment (window/document).
+ */
+export const downloadFile = async (path: string): Promise<void> => {
+  const root = await getOPFSRoot();
+  const normalized = normalizeRelPath(path);
+
+  const dir = await getParentDirHandle(root, normalized, /*create*/ false);
+  const base = normalized.split("/").pop()!;
+
+  const fh = await dir.getFileHandle(base, { create: false });
+  const file = await fh.getFile();
+
+  if (typeof document === "undefined") {
+    throw new Error("downloadFile requires a DOM environment (window/document).");
+  }
+
+  const url = URL.createObjectURL(file);
+  try {
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = base;
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+};


### PR DESCRIPTION
## Summary
- add read/write/delete/download utilities for OPFS
- expose CRUD helpers via package entrypoint and playground panel
- document CRUD usage in opfs-utils docs

## Testing
- `npm run format:check`
- `npm run lint`
- `npm run build --workspace @pstdio/opfs-utils`
- `npm run test --workspace @pstdio/opfs-utils` *(fails: Cannot find package 'jsdom')*


------
https://chatgpt.com/codex/tasks/task_e_68b5b91dfac88321a39416081eeadf85